### PR TITLE
remove depends statement

### DIFF
--- a/examples/private_zone/main.tf
+++ b/examples/private_zone/main.tf
@@ -46,6 +46,4 @@ module "dns_zone" {
 
   zones = local.zones
   tags  = var.tags
-
-  depends_on = [module.vpc]
 }


### PR DESCRIPTION
This is to fix this error, from the private_repo example:

```
╷
│ Error: Module is incompatible with count, for_each, and depends_on
│ 
│   on main.tf line 50, in module "dns_zone":
│   50:   depends_on = [module.vpc]
│ 
│ The module at module.dns_zone is a legacy module which contains its own local provider configurations, and so calls
│ to it may not use the count, for_each, or depends_on arguments.
│ 
│ If you also control the module "../..", consider updating this module to instead expect provider configurations to be
│ passed by its caller.
╵

make[2]: *** [tfmodule/init] Error 1
make[1]: *** [test] Error 2
make: *** [check] Error 2
```
